### PR TITLE
[Change]order.rb/enum,order_status=>status

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,5 +2,5 @@ class Order < ApplicationRecord
    belongs_to :customer
    has_many :cart_items
 # enum注文ステータスの値
-   enum order_status: {入金待ち:0, 入金確認:1, 製作中:2, 発送準備中:3, 発送済:4}
+   enum status: {入金待ち:0, 入金確認:1, 製作中:2, 発送準備中:3, 発送済:4}
 end


### PR DESCRIPTION
「order.rb」内の注文ステータスのカラム名を「order_status」から「status」に修正しました。