### PR TITLE
[Finish]debug-public_item_show&cart_items

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -9,9 +9,14 @@ class Public::CartItemsController < ApplicationController
     @cart_item_check = CartItem.find_by(customer_id: current_customer.id, item_id: params[:cart_item][:item_id])
     if @cart_item_check
       @cart_item_check.amount += params[:cart_item][:amount].to_i
-      @cart_item_check.save
-      flash[:notice] = "カートに商品を追加しました"
-      redirect_to cart_items_path
+      if @cart_item_check.amount < 11
+         @cart_item_check.save
+         flash[:notice] = "カートに商品を追加しました"
+         redirect_to cart_items_path
+      else
+         flash[:notice] = "カートの上限数を超えています"
+         redirect_back(fallback_location: root_path)
+      end
     else
       @cart_item = CartItem.new(cart_item_params)
       @cart_item.customer_id = current_customer.id

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -1,15 +1,5 @@
 <div class="container">
   <div class="row">
-    <% if @cart_item_check.errors.any? %>
-    <ul class="alert alert-danger" role="alert">
-      <h6 class="alert-heading">
-        <%= @cart_item_check.errors.count %>件のエラーが発生しました
-      </h6>
-      <% @cart_item_check.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
-    <% end %>
       <h2>ショッピングカート</h2>
     <% unless @cart_items.empty? %>
       <%= link_to "カートを空にする", destroy_all_cart_items_path, class: "btn btn-danger float-right", id: "destroy_all", method: :delete, data: { confirm: 'カート内の商品を全て削除しますか？' } %>
@@ -38,14 +28,14 @@
           <% @cart_items.each.with_index(1) do |cart_item, i| %>
             <tr>
               <td class="align-middle" ><%= image_tag cart_item.item.get_item_image(500, 500), size: "50x50", class: "w-100 rounded" %><%= cart_item.item.name %></td>
-              <td class="align-middle"><%= tax_incluted_price(cart_item.item.tax_incluted_price).to_s(:delimited) %></td>
+              <td class="align-middle"><%= cart_item.item.tax_incluted_price.to_s(:delimited) %></td>
               <td class="align-middle">
                 <%= form_with model: cart_item, local: true do |f| %>
                 <%= f.select :amount, *[1..10], id: "amount-select-#{i}" %>
                 <%= f.submit "変更", class: "btn btn-success" %>
                 <% end %>
               </td>
-              <td class="align-middle"><%= (amount = tax_incluted_price(cart_item.item.tax_incluted_price * cart_item.amount)).to_s(:delimited) %></td>
+              <td class="align-middle"><%= (amount = cart_item.item.tax_incluted_price * cart_item.amount).to_s(:delimited) %></td>
               <td class="align-middle text-center"><%= link_to "削除する", cart_item_path(cart_item), class: "btn btn-danger", id: "cart-item-delete-#{i}", method: :delete, data: { confirm: 'こちらの商品を削除しますか？' } %></td>
             </tr>
             <% @sum += amount %>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -20,18 +20,18 @@
           <% end %>
         </ul>
       <% end %>
-     <%= image_tag item.get_item_image(500, 500), size: "150x150", class: "w-100 rounded" %>
+     <%= image_tag @item.get_item_image(500, 500), size: "150x150", class: "w-100 rounded" %>
     </div>
     <h3><strong><%= @item.name %></strong></h3>
     <h4><%= simple_format(@item.body)%></h4>
       <% if @item.is_sale == true %>
         <p class="text-success">販売中</p>
-        <h3>¥ <%= tax_incluted_price( @item.tax_incluted_price ) %> <small>(税込)</small></h3>
+        <h3>¥ <%= @item.tax_incluted_price %> <small>(税込)</small></h3>
         <% if current_customer %>
           <p>
             <%= form_with model: @cart_item, local: true do |f| %>
-              <%= f.hidden_field :item_id, :value @item.id %>
-              <%= f.number_field :amount, in: 1..99, placeholder: "個数を選択" %>
+              <%= f.hidden_field :item_id, value: @item.id %>
+              <%= f.select :amount, *[1..10], placeholder: "個数を選択" %>
               <%= f.submit "カートに入れる", class: "btn btn-success" %>
             <% end %>
           </p>
@@ -39,7 +39,7 @@
           <%= link_to "ログインはこちらから", new_customer_session_path %>
         <% end %>
       <% else %>
-        <h3 class="text-danger">売り切れ</h3>
+        <h3 class="text-danger">販売停止中</h3>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
顧客側　デバッグ：　商品一覧画面、商品詳細画面
　　　　
　　　　変更：　商品詳細画面の数量選択を１～１０個のプルダウンメニュー式に変更
　　　　　　
　　　　追加：　商品詳細画面から同じ商品を追加する際、カート内商品の合計数量が１０個以下になるなら追加し、
　　　　　　　　１１個以上になるときは追加せず注文商品詳細画面にフラッシュメッセージを表示します。